### PR TITLE
Require login to access Todo features (in progress)

### DIFF
--- a/app/src/components/header/header.html
+++ b/app/src/components/header/header.html
@@ -4,7 +4,7 @@
       <ngc-icon-logo></ngc-icon-logo> ngCourse2
     </p>
   </div>
-  <div class="right">
+  <div class="right" *ngIf="authService.isLogged()">
     <a class="btn py2 m0"
       [routerLink]="['Main', 'TasksList']">Tasks</a>
     <a class="btn py2 m0"
@@ -12,7 +12,7 @@
     <a id="qa-logout-link"
       class="btn py2 m0"
       href="#"
-      ng-click="ctrl.logout()">
+      (click)="logout()">
       Logout
     </a>
   </div>

--- a/app/src/components/header/header.ts
+++ b/app/src/components/header/header.ts
@@ -1,6 +1,7 @@
 import {Component} from 'angular2/core';
 import {RouterLink} from 'angular2/router';
 import LogoIcon from '../icons/logo';
+import {AuthService} from '../../services/auth-service';
 const TEMPLATE = require('./header.html');
 
 @Component({
@@ -12,8 +13,12 @@ export default class Header {
 
   private today: Date;
 
-  constructor() {
+  constructor(public authService: AuthService) {
     this.today = new Date();
+  }
+  
+  logout() {
+    this.authService.logout();
   }
 
 }

--- a/app/src/components/login/login.html
+++ b/app/src/components/login/login.html
@@ -1,0 +1,29 @@
+<div class="sm-col-6 mx-auto border rounded mb4"
+  *ngIf="!authService.isLogged()">
+
+  <div class="p2 gray bg-darken-1">
+    <h4 class="m0 caps">Login</h4>
+  </div>
+
+  <div class="p2 white bg-red" *ngIf="message">
+    {{ message }}
+  </div>
+
+  <form class="p2 bg-white">
+      <label for="username">User:</label>
+      <input class="block col-12 mb1 field"
+        type="text"
+        name="username"
+        #username>
+      <label for="password">Password:</label>
+      <input class="block col-12 mb1 field"
+        type="password"
+        name="password"
+        #password>
+      <button class="btn btn-primary"
+        (click)="login(username.value, password.value)">
+        Login
+      </button>
+  </form>
+
+</div>

--- a/app/src/components/login/login.ts
+++ b/app/src/components/login/login.ts
@@ -1,0 +1,29 @@
+import {Component} from 'angular2/core';
+import {AuthService} from '../../services/auth-service';
+const TEMPLATE = require('./login.html');
+
+@Component({
+  selector: 'login',
+  template: TEMPLATE
+})
+export default class LoginComponent {
+  message: string;
+
+  constructor(public authService: AuthService) {
+    this.message = '';
+  }
+
+  login(username: string, password: string): boolean {
+    this.message = '';
+    if (!this.authService.login(username, password)) {
+      this.message = 'Incorrect credentials.';
+      return false;
+    }
+    return true;
+  }
+
+  logout(): boolean {
+    this.authService.logout();
+    return false;
+  }
+}

--- a/app/src/components/main/main.ts
+++ b/app/src/components/main/main.ts
@@ -1,11 +1,10 @@
 import {Component, Injector} from 'angular2/core';
-import {RouteConfig, RouterOutlet, CanActivate} from 'angular2/router';
+import {RouteConfig, RouterOutlet} from 'angular2/router';
 import TaskAdd from '../task-add/task-add';
 import TaskEdit from '../task-edit/task-edit';
 import TasksList from '../tasks-list/tasks-list';
 import Summary from '../summary/summary';
 import TasksService from '../../services/tasks-service';
-import {AuthService} from '../../services/auth-service';
 
 @Component({
   selector: 'ngc-main',
@@ -29,11 +28,4 @@ import {AuthService} from '../../services/auth-service';
   name: 'TaskEdit',
   component: TaskEdit
 }])
-@CanActivate(
-  (nextInstr: any, currInstr: any) => {
-    let injector: any = Injector.resolveAndCreate([AuthService]);
-    let authService: AuthService = injector.get(AuthService);
-    return authService.isLogged();
-  }
-)
 export default class Main {}

--- a/app/src/components/main/main.ts
+++ b/app/src/components/main/main.ts
@@ -1,10 +1,11 @@
-import {Component} from 'angular2/core';
-import {RouteConfig, RouterOutlet} from 'angular2/router';
+import {Component, Injector} from 'angular2/core';
+import {RouteConfig, RouterOutlet, CanActivate} from 'angular2/router';
 import TaskAdd from '../task-add/task-add';
 import TaskEdit from '../task-edit/task-edit';
 import TasksList from '../tasks-list/tasks-list';
 import Summary from '../summary/summary';
 import TasksService from '../../services/tasks-service';
+import {AuthService} from '../../services/auth-service';
 
 @Component({
   selector: 'ngc-main',
@@ -28,4 +29,11 @@ import TasksService from '../../services/tasks-service';
   name: 'TaskEdit',
   component: TaskEdit
 }])
+@CanActivate(
+  (nextInstr: any, currInstr: any) => {
+    let injector: any = Injector.resolveAndCreate([AuthService]);
+    let authService: AuthService = injector.get(AuthService);
+    return authService.isLogged();
+  }
+)
 export default class Main {}

--- a/app/src/containers/app.ts
+++ b/app/src/containers/app.ts
@@ -1,21 +1,25 @@
 import {Component} from 'angular2/core';
 import {RouteConfig, ROUTER_DIRECTIVES} from 'angular2/router';
+import {LoggedInRouterOutlet} from '../logged-in-outlet';
 import Header from '../components/header/header';
 import Main from '../components/main/main';
 import Login from '../components/login/login';
 
 @Component({
   selector: 'ngc-root',
-  directives: [ROUTER_DIRECTIVES, Header, Login],
+  directives: [ROUTER_DIRECTIVES, Header, Login, LoggedInRouterOutlet],
   template: `
   <ngc-header></ngc-header>
   <div class="container px2 mt4">
-    <login></login>
-    <router-outlet></router-outlet>
+    <loggedin-router-outlet></loggedin-router-outlet>
   </div>
   `
 })
 @RouteConfig([{
+  path: '/login',
+  name: 'Login',
+  component: Login
+}, {
   path: '/tasks/...',
   name: 'Main',
   component: Main,
@@ -23,5 +27,6 @@ import Login from '../components/login/login';
 }, {
   path: '/',
   redirectTo: ['Main']
-}])
+}
+])
 export default class App {}

--- a/app/src/containers/app.ts
+++ b/app/src/containers/app.ts
@@ -2,13 +2,15 @@ import {Component} from 'angular2/core';
 import {RouteConfig, ROUTER_DIRECTIVES} from 'angular2/router';
 import Header from '../components/header/header';
 import Main from '../components/main/main';
+import Login from '../components/login/login';
 
 @Component({
   selector: 'ngc-root',
-  directives: [ROUTER_DIRECTIVES, Header],
+  directives: [ROUTER_DIRECTIVES, Header, Login],
   template: `
   <ngc-header></ngc-header>
   <div class="container px2 mt4">
+    <login></login>
     <router-outlet></router-outlet>
   </div>
   `

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -3,6 +3,7 @@ import {ROUTER_PROVIDERS, APP_BASE_HREF} from 'angular2/router';
 import {bootstrap} from 'angular2/bootstrap';
 import { HTTP_PROVIDERS } from 'angular2/http';
 import App from './containers/app';
+import {AUTH_PROVIDERS} from './services/auth-service';
 import TasksService from './services/tasks-service';
 const BASE_STYLES = require('!style!css!postcss!./styles/app.css');
 
@@ -10,6 +11,7 @@ bootstrap(
   App, [
     HTTP_PROVIDERS,
     ROUTER_PROVIDERS,
+    AUTH_PROVIDERS,
     TasksService,
     provide(APP_BASE_HREF, { useValue: '/' })
   ]

--- a/app/src/logged-in-outlet.ts
+++ b/app/src/logged-in-outlet.ts
@@ -1,0 +1,44 @@
+import {Directive, Attribute, ElementRef, DynamicComponentLoader} from 'angular2/core';
+import {Router, RouterOutlet, ComponentInstruction} from 'angular2/router';
+import {AuthService} from './services/auth-service';
+
+@Directive({
+  selector: 'loggedin-router-outlet'
+})
+export class LoggedInRouterOutlet extends RouterOutlet {
+  publicRoutes: any;
+  private parentRouter: Router;
+
+  constructor(
+    _elementRef: ElementRef,
+    _loader: DynamicComponentLoader,
+    _parentRouter: Router,
+    @Attribute('name') nameAttr: string
+  ) {
+    super(_elementRef, _loader, _parentRouter, nameAttr);
+
+    this.parentRouter = _parentRouter;
+    this.publicRoutes = {
+      '/login': true
+    };
+  }
+
+  activate(instruction: ComponentInstruction) {
+
+    const url = this.parentRouter.lastNavigationAttempt;
+    // Replace with AuthService.isLogged();
+    const isLoggedIn = false;
+    const isPublicRoute = !!this.publicRoutes[url];
+
+    console.log('ComponentInstruction', ComponentInstruction);
+    console.log('url', url);
+    console.log('isLoggedIn', isLoggedIn);
+    console.log('isPublicRoute', isPublicRoute);
+
+    if (!isPublicRoute && !isLoggedIn) {
+      console.log("REDIRECT TO LOGIN");
+      this.parentRouter.navigateByUrl('/login');
+    }
+    return super.activate(instruction);
+  }
+}

--- a/app/src/services/auth-service.ts
+++ b/app/src/services/auth-service.ts
@@ -1,0 +1,33 @@
+import {Injectable, provide} from 'angular2/core';
+// import {Router} from 'angular2/router';
+
+@Injectable()
+export class AuthService {
+
+  // constructor(private _router: Router) {}
+
+  login(user: string, password: string): boolean {
+    if (user === 'user' && password === 'pass') {
+      localStorage.setItem('username', user);
+      return true;
+    }
+    return false;
+  }
+
+  logout(): any {
+    localStorage.removeItem('username');
+    // this._router.navigate(['/Main']);
+  }
+
+  getUser(): any {
+    return localStorage.getItem('username');
+  }
+
+  isLogged(): boolean {
+    return this.getUser() !== null;
+  }
+}
+
+export var AUTH_PROVIDERS: Array<any> = [
+  provide(AuthService, {useClass: AuthService})
+];


### PR DESCRIPTION
Add Login component and AuthService, which checks against a hard coded user/password for now. Session state is kept in local storage. This should be expanded to use a remote auth service - not certain if this is supported by ngcourse-api currently.

This uses the `@CanActivate` router hook decorator to limit access to Todo features. I am looking for feedback on how Observables can be incorporated and related to course content since that topic was mentioned in the [Trello card](https://trello.com/c/teaSrnio/93-login).