### PR TITLE
Chore refactor task filters

### DIFF
--- a/app/src/components/task-filters/task-filters.ts
+++ b/app/src/components/task-filters/task-filters.ts
@@ -1,28 +1,27 @@
-import {Component} from 'angular2/core';
+import {Component, Input, Output, EventEmitter} from 'angular2/core';
 import Dropdown from '../dropdown/dropdown'; 
 import {SizePipe} from '../../pipes/size';
 import {OwnersPipe, OwnerTasksPipe} from '../../pipes/owners';
-import {List} from 'immutable';
+import {List, Map} from 'immutable';
 const TEMPLATE = require('./task-filters.html');
 
 @Component({
   selector: 'ngc-task-filters',
   pipes: [OwnersPipe, OwnerTasksPipe, SizePipe],
   directives: [Dropdown],
-  inputs: [
-    'tasks',
-    'owner',
-    'taskStatus',
-    'selectOwner',
-    'selectStatus'
-  ],
   template: TEMPLATE
 })
 export default class TaskFilters {
 
+  @Input() tasks: List<Map<string, any>>;
+  @Input() owner: string;
+  @Input() taskStatus: string;
+
+  @Output() ownerChanged: EventEmitter<string> = new EventEmitter<string>();
+  @Output() taskStatusChanged: EventEmitter<string> = new EventEmitter<string>();
+
   statuses: List<string>; 
-  selectOwner: Function;
-  selectStatus: Function;
+  
 
   constructor() {
     this.statuses = List(['all', 'completed', 'incomplete']);
@@ -30,11 +29,11 @@ export default class TaskFilters {
 
   onSelectOwner($event) {
     const owner = $event.target.value;
-    this.selectOwner(owner);
+    this.ownerChanged.emit(owner);
   }
 
   onSelectStatus($event) {
     const newStatus = $event.target.value;
-    this.selectStatus(newStatus);
+    this.taskStatusChanged.emit(newStatus);
   }
 }

--- a/app/src/containers/summary.ts
+++ b/app/src/containers/summary.ts
@@ -27,8 +27,8 @@ import {List} from 'immutable';
     [tasks]="tasks"
     [owner]="owner"
     [taskStatus]="taskStatus"
-    [selectOwner]="selectOwner"
-    [selectStatus]="selectStatus">
+    (ownerChanged)="selectOwner($event)"
+    (taskStatusChanged)="selectStatus($event)">
   </ngc-task-filters>
   `
 })
@@ -38,8 +38,7 @@ export default class Summary implements OnDestroy, OnInit {
   tasks: List<TaskMap>;
   owner: string;
   taskStatus: string;
-  selectOwner: Function;
-  selectStatus: Function;
+  
 
   constructor( @Inject('ngRedux') private ngRedux ) {}
 


### PR DESCRIPTION
@bennett000 @winkerVSbecks 
Was playing around with the `kitchen-sink` in another repo, and noticed that when passing callbacks as inputs, the context of 'this' gets weird. 

when in the callback in kitchen-sink, 'this' was pointing to TaskFilter, even when trying to change the callback to be defined like `myCb = (x:any) => { }`

Changing things to event emitter started to get the expected behavior. 