### PR TITLE
Refactor task actions to not take callback

### DIFF
--- a/app/src/containers/task-add/task-add.ts
+++ b/app/src/containers/task-add/task-add.ts
@@ -41,8 +41,7 @@ export default class TaskAdd implements OnDestroy, OnInit {
 
   submitTask(newTask): void {
     
-    this.addTask(newTask, () => {
-      this._router.navigate(['/Tasks']);
-    });
+    this.addTask(newTask)
+      .subscribe( _ => this._router.navigate(['/Tasks']));
   }
 }

--- a/app/src/containers/task-edit/task-edit.ts
+++ b/app/src/containers/task-edit/task-edit.ts
@@ -19,7 +19,7 @@ export default class TaskEdit implements OnDestroy, OnInit {
   task: Map<string, any>;
   updateTask: Function;
   cancelLink: any[] = ['/Tasks']
-
+  
   get taskId(): string {
     return this._params.get('id');
   }
@@ -39,6 +39,7 @@ export default class TaskEdit implements OnDestroy, OnInit {
 
   ngOnDestroy() {
     this.unsubscribe();
+    
   }
 
   mapStateToThis = (state) => {
@@ -53,8 +54,8 @@ export default class TaskEdit implements OnDestroy, OnInit {
   }
 
   submitTask(taskForm): void {
-    this.updateTask(taskForm, () => {
-      this._router.navigate(['/Tasks']);
-    });
+    this.updateTask(taskForm).subscribe(_ => this._router.navigate(['/Tasks']));
   }
+
+
 }

--- a/app/src/services/tasks-service.ts
+++ b/app/src/services/tasks-service.ts
@@ -1,6 +1,7 @@
 import {Inject} from 'angular2/core';
 import {Http, Request, Response, Headers} from 'angular2/http';
 import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/share';
 import {List, Map} from 'immutable';
 
 export interface Task {
@@ -23,33 +24,40 @@ export default class TasksService {
 
   fetch() {
     return this._http.get('http://ngcourse.herokuapp.com/api/v1/tasks')
-      .map((res: Response) => res.json());
+      .map((res: Response) => res.json())
+      .share();
   }
 
   add(task: Task) {
+    delete task._id;
     return this._http.post(
       'http://ngcourse.herokuapp.com/api/v1/tasks',
       JSON.stringify(task), {
         headers: HEADERS
       }
     )
-    .map((res: Response) => res.json());
+      .map((res: Response) => res.json())
+      .share();
   }
 
   update(task: Task) {
+    
     return this._http.put(
       `http://ngcourse.herokuapp.com/api/v1/tasks/${task._id}`,
       JSON.stringify(task), {
         headers: HEADERS
       }
     )
-    .map((res: Response) => res.json());
+      .map((res: Response) => res.json())
+      .share();
+    
   }
 
   delete(task: TaskMap) {
     return this._http.delete(
       `http://ngcourse.herokuapp.com/api/v1/tasks/${task.get('_id')}`
     )
-    .map((res: Response) => res.json());
+      .map((res: Response) => res.json())
+      .share();
   }
 }


### PR DESCRIPTION
Previous version had you passing in a callback for the success of an API call. I didn't like this, and wanted to switch it to returning the observable sequence.

Initially I tried just doing

```
x = task.add(x)
x.subscribe()
return x;
// in my component
x.subscribe()
```

but it would fire off the HTTP request twice. This seems to be giving me the results I expect, but is this the right way to be doing it?


@AbdellaToronto @igor-ka @winkerVSbecks @bennett000 

Still a little rusty with RxJs Observables - feedback?