### PR TITLE
Change default port for gitbook to 3000

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "gitbook build",
-    "dev": "gitbook serve",
+    "dev": "gitbook --port 3000 serve",
     "postinstall": "gitbook install"
   },
   "repository": {


### PR DESCRIPTION
When start the server gitbook is listening in the port 4000 and in the README it says 3000.