### PR TITLE
Simpler and better way to type optional parameters.

### DIFF
--- a/exercises/features/typescript/3.0-type-shapes_solution/app/exercise.ts
+++ b/exercises/features/typescript/3.0-type-shapes_solution/app/exercise.ts
@@ -72,9 +72,12 @@ interface NodeCallback {
   (error: Error, data?: any): void;
 }
 
-function accessor(db: Dictionary, key: string, callback: NodeCallback);
-function accessor(db: Dictionary, key: string, value: any,
-                  callback: NodeCallback) {
+function accessor(
+  db: Dictionary,
+  key: string,
+  value?: any,
+  callback?: NodeCallback
+) {
   let cb: NodeCallback;
   if (typeof callback === 'function') {
     cb = callback;


### PR DESCRIPTION
(For TS exercise 3).

The solution involving overloads was broken, generally I don't consider TS overloads to be useful anyway unless you have completely disjoint function implementations (which JS doesn't allow). So, you're better off using optional params and union return types in almost all cases I have encountered so far.

Fixes #172 