### PR TITLE
Fixed typo in 'tslint' npm package name

### DIFF
--- a/handout/features/linting.md
+++ b/handout/features/linting.md
@@ -5,7 +5,7 @@ check for computer programs.  Linting can be done in a programmer's editor,
 and/or through automation.
 
 For TypeScript there is a package called `tslint`, (`npm install --save-dev
-ts-lint`) which can be plugged into many editors.  `tslint` can also be
+tslint`) which can be plugged into many editors.  `tslint` can also be
 configured with a `tslint.json` file.
 
 Webpack can also run `tslint` _before_ it even attempts to run `tsc`.  This is


### PR DESCRIPTION
Fixed a small typo. The npm package that does the TypeScript linting should be `tslint` rather than `ts-lint`.