### PR TITLE
remove chai from remaining tests in handout

### DIFF
--- a/handout/testing/redux/async-actions.md
+++ b/handout/testing/redux/async-actions.md
@@ -60,8 +60,8 @@ describe('counter action creators', () => {
           }
         },
         dispatch: (action) => {
-          chai.expect(action)
-            .to.deep.equal(expectedAction);
+          expect(action)
+            .toEqual(expectedAction);
 
           done();
         }
@@ -101,8 +101,8 @@ it('incrementIfOdd should dispatch INCREMENT_COUNTER if counter is odd',
       dispatch: (action) => {
         const expectedAction = expectedActions.shift();
 
-        chai.expect(action)
-          .to.deep.equal(expectedAction);
+        expect(action)
+          .toEqual(expectedAction);
 
         if (expectedActions.length === 0) {
           done();

--- a/handout/testing/redux/reducers.md
+++ b/handout/testing/redux/reducers.md
@@ -26,28 +26,28 @@ import counter from './counter';
 
 describe('counter reducers', () => {                                     
   it('should handle initial state', () => {                              
-    chai.expect(                                                         
+    expect(                                                         
       counter(undefined, {})                                             
     )                                                                    
-    .to.equal(0)                                                         
+    .toEqual(0)                                                         
   });                                                                    
 
   it('should handle INCREMENT_COUNTER', () => {                          
-    chai.expect(                                                         
+    expect(                                                         
       counter(0, {                                                       
         type: INCREMENT_COUNTER                                          
       })                                                                 
     )                                                                    
-    .to.equal(1)                                                         
+    .toEqual(1)                                                         
   });                                                                    
 
   it('should handle DECREMENT_COUNTER', () => {                          
-    chai.expect(                                                         
+    expect(                                                         
       counter(1, {                                                       
         type: DECREMENT_COUNTER                                          
       })                                                                 
     )                                                                    
-    .to.equal(0)                                                         
+    .toEqual(0)                                                         
   });                                                                    
 });
 ```

--- a/handout/testing/redux/synchronous-actions.md
+++ b/handout/testing/redux/synchronous-actions.md
@@ -32,15 +32,15 @@ import * as CounterActions from './counter';
 
 describe('counter action creators', () => {                     
   it('increment should create INCREMENT_COUNTER action', () => {
-    chai.expect(CounterActions.increment())                     
-      .to.deep.equal({                                          
+    expect(CounterActions.increment())                     
+      .toEqual({                                          
         type: INCREMENT_COUNTER                                 
       });                                                       
   });                                                           
 
   it('decrement should create DECREMENT_COUNTER action', () => {
-    chai.expect(CounterActions.decrement())                     
-      .to.deep.equal({                                          
+    expect(CounterActions.decrement())                     
+      .toEqual({                                          
         type: DECREMENT_COUNTER                                 
       });                                                       
   });                                                           


### PR DESCRIPTION
We should update the app to not use chai as well.