### PR TITLE
Update basic router example to router 3

### DIFF
--- a/examples/routing/routing-basic-example/app/app.component.ts
+++ b/examples/routing/routing-basic-example/app/app.component.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {RouteConfig, ROUTER_DIRECTIVES} from '@angular/router-deprecated';
+import {ROUTER_DIRECTIVES} from '@angular/router';
 import ComponentOne from './component-one';
 import ComponentTwo from './component-two';
 
@@ -10,8 +10,8 @@ import ComponentTwo from './component-two';
 	template: `<div>
 	Basic Routing
 	<ul>
-	  <li><a [routerLink]="['/ComponentOne']">Component One</a></li>
-	  <li><a [routerLink]="['/ComponentTwo']">Component Two</a></li>
+	  <li><a [routerLink]="['/component-one']">Component One</a></li>
+	  <li><a [routerLink]="['/component-two']">Component Two</a></li>
 	</ul>
 	<div style="border: 1px solid black">
 	  <router-outlet></router-outlet>
@@ -19,10 +19,6 @@ import ComponentTwo from './component-two';
 	
 	`
 })
-@RouteConfig([
-  {path: '/componentOne', as: 'ComponentOne', useAsDefault: true, component: ComponentOne},
-  {path: '/componentTwo', as: 'ComponentTwo', useAsDefault: false, component: ComponentTwo}
-  ])
 export class SimpleRouting {
   
 }

--- a/examples/routing/routing-basic-example/app/index.ts
+++ b/examples/routing/routing-basic-example/app/index.ts
@@ -1,7 +1,18 @@
 import {bootstrap} from '@angular/platform-browser-dynamic'
-import {ROUTER_PROVIDERS} from '@angular/router-deprecated'
+
 import {LocationStrategy, HashLocationStrategy} from '@angular/common'
 import {provide} from '@angular/core'
 import {SimpleRouting} from './app.component'
+import { provideRouter, RouterConfig } from '@angular/router';
+import ComponentOne from './component-one';
+import ComponentTwo from './component-two';
 
-bootstrap(SimpleRouting, [ROUTER_PROVIDERS, provide(LocationStrategy, {useClass: HashLocationStrategy})]);
+const routerConfig: RouterConfig =
+[
+  {path: '/component-one', useAsDefault: true, component: ComponentOne},
+  {path: '/component-two', useAsDefault: false, component: ComponentTwo}
+] 
+bootstrap(SimpleRouting, [
+  provideRouter(routerConfig),
+  provide(LocationStrategy, {useClass: HashLocationStrategy})
+  ]);

--- a/examples/routing/routing-basic-example/system.config.js
+++ b/examples/routing/routing-basic-example/system.config.js
@@ -1,5 +1,5 @@
 var angularVersion = '2.0.0-rc.1';
-
+var routerVer = '@3.0.0-alpha.3'; // lock router version
 System.config({
   baseUrl: '/',
   paths: {
@@ -30,8 +30,9 @@ System.config({
     '@angular/common': 'npmcdn:@angular/common@'+angularVersion,
     '@angular/platform-browser': 'npmcdn:@angular/platform-browser@'+angularVersion,
     '@angular/platform-browser-dynamic': 'npmcdn:@angular/platform-browser-dynamic@'+angularVersion,
+    '@angular/router':            'https://npmcdn.com/@angular/router' + routerVer,
     '@angular/http': 'npmcdn:@angular/http@'+angularVersion,
-    '@angular/router-deprecated': 'npmcdn:@angular/router-deprecated@'+angularVersion,
+   // '@angular/router-deprecated': 'npmcdn:@angular/router-deprecated@'+angularVersion,
     'immutable': 'npmcdn:immutable@3.8.1',
     'redux': 'https://npmcdn.com/redux@2.0.0/dist/redux.js',
     'ng2-redux': 'npmcdn:ng2-redux@2.3.2',


### PR DESCRIPTION
@winkerVSbecks @bennett000 @SethDavenport 

Playing with new router and moving an example from deprecated to router 3. 

Main changes:

* What was once in `@RouteConfig` is now just an array
* That gets fed into the `provideRouter` during bootstrap 
* routerLink DSL is mostly the same, except the `as` from the config is gone - and seems like you need to give it a path, instead of a name that it's registered as.