### PR TITLE
Get npm install; npm run dev to work.

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,20 +1,15 @@
 {
   "plugins": [
     "highlight",
-    "theme-default",
     "ga"
   ],
   "styles": {
     "ebook": "styles/ebook.css",
     "pdf": "styles/pdf.css"
   },
-  "theme": "theme-default",
   "pluginsConfig": {
     "ga": {
       "token": "UA-41067508-7"
-    },
-    "theme-default": {
-      "showLevel": true
     }
   },
   "structure": {


### PR DESCRIPTION
I was getting this trying to run the gitbook locally:

`npm install`:

```
info: 2 plugins to install
info: No version specified, resolve plugin theme-default

Found no satisfactory version for plugin theme-default
```

Nuking settings related to this theme seems to fix it but I'd like someone knowledgeable about gitbook to take a look in case I'm doing something silly.