### PR TITLE
[Fixes #161] Remove obsolete codepen example.

### DIFF
--- a/handout/observables/README.md
+++ b/handout/observables/README.md
@@ -1,12 +1,10 @@
 # Observables
 
-One of the new improved features introduced in Angular 2 are Observables. Observables aren't an Angular 2 specific feature, its a proposed standard for managing async data that will be included in the release of ES7. Observables open up a continuous channel of communication in which multiple values of data can be emitted over time. From this we get a pattern of dealing with data by using array like operations to parse, modify and maintain data. Angular 2 uses Observables extensively, you'll see them in the HTTP service and the event system.
-
-
-<iframe class="no-pdf" height='268' scrolling='no'
-    src='//codepen.io/winkerVSbecks/embed/xZjGZo/?height=268&theme-id=21941&default-tab=result'
-    frameborder='no'
-    allowtransparency='true'
-    allowfullscreen='true'
-    style='width: 100%;'>
-</iframe>
+An exciting new feature used with Angular 2 is the `Observable`. This isn't an
+Angular 2 specific feature, but rather it's a proposed standard for managing
+async data that will be included in the release of ES7. Observables open up a
+continuous channel of communication in which multiple values of data can be
+emitted over time. From this we get a pattern of dealing with data by using
+array-like operations to parse, modify and maintain data. Angular 2 uses
+Observables extensively, you'll see them in the HTTP service and the event
+system.


### PR DESCRIPTION
Also adjusted the copy on this page slightly to account for some cardinality disagreements and other examples of awkward wording.