### PR TITLE
fix rc2 breaks - #280

### DIFF
--- a/app/src/components/login/login.ts
+++ b/app/src/components/login/login.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {Router} from '@angular/router-deprecated';
 import {
-  FORM_BINDINGS,
+  FORM_PROVIDERS,
   FORM_DIRECTIVES,
   ControlGroup,
   FormBuilder,
@@ -13,7 +13,7 @@ const TEMPLATE = require('./login.html');
 @Component({
   selector: 'login',
   directives: [FORM_DIRECTIVES],
-  viewProviders: [FORM_BINDINGS],
+  viewProviders: [FORM_PROVIDERS],
   template: TEMPLATE
 })
 export default class LoginComponent {

--- a/app/src/components/task-add/task-add.ts
+++ b/app/src/components/task-add/task-add.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {RouterLink} from '@angular/router-deprecated';
 import {
-  FORM_BINDINGS,
+  FORM_PROVIDERS,
   FORM_DIRECTIVES,
   ControlGroup,
   FormBuilder,
@@ -13,7 +13,7 @@ const TEMPLATE = require('./task-add.html');
 @Component({
   selector: 'ngc-task-add',
   directives: [RouterLink, FORM_DIRECTIVES],
-  viewBindings: [FORM_BINDINGS],
+  viewProviders: [FORM_PROVIDERS],
   template: TEMPLATE
 })
 export default class TaskAdd {

--- a/app/src/components/task-edit/task-edit.ts
+++ b/app/src/components/task-edit/task-edit.ts
@@ -5,7 +5,7 @@ import {
   ROUTER_DIRECTIVES
 } from '@angular/router-deprecated';
 import {
-  FORM_BINDINGS,
+  FORM_PROVIDERS,
   FORM_DIRECTIVES,
   ControlGroup,
   FormBuilder,
@@ -17,7 +17,7 @@ const TEMPLATE = require('./task-edit.html');
 @Component({
   selector: 'ngc-task-edit',
   directives: [RouterLink, ROUTER_DIRECTIVES, FORM_DIRECTIVES],
-  viewBindings: [FORM_BINDINGS],
+  viewProviders: [FORM_PROVIDERS],
   template: TEMPLATE
 })
 export default class TaskEdit {


### PR DESCRIPTION
* FORM_BINDINGS -> FORM_PROVIDERS
* viewBindings: -> viewProviders

These will eventually be deprecated,

> It looks like you're using the old forms module. This will be opt-in in
> the next RC, and
>      will eventually be removed in favor of the new forms module. For
> more information, see:
>      https://docs.google.com/document/u/1/d/1RIezQqE4aEhBRmArIAS1mRIZtWFf6JxN_7B4meyWK0Y/pub

Will need to update again later, but this will at least let the app run
/ tests run and pass now.