### PR TITLE
Increase mentions of ngrx in Redux section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -163,14 +163,14 @@
 
 ---
 
-* [Redux](handout/redux/README.md)
+* [Redux and Ngrx](handout/redux/README.md)
    * [Review of Reducers and Pure Functions](handout/redux/review_of_reducers_and_pure_functions.md)
-   * [Redux Reducers](handout/redux/redux_reducers.md)
+   * [Reducers as State Management](handout/redux/reducers_as_state_management.md)
    * [Redux Actions](handout/redux/redux_actions.md)
    * [Configuring your Application to use Redux](handout/redux/configuring_your_application_to_use_redux.md)
    * [Using Redux with Components](handout/redux/using_redux_with_components.md)
    * [Redux and Component Architecture](handout/redux/redux_and_component_architecture.md)
-
+   * [Getting More from Redux and Ngrx](handout/redux/getting_more_from_redux_and_ngrx.md)
 ---
 
 * [TDD Testing](handout/testing/README.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -170,7 +170,7 @@
    * [Configuring your Application to use Redux](handout/redux/configuring_your_application_to_use_redux.md)
    * [Using Redux with Components](handout/redux/using_redux_with_components.md)
    * [Redux and Component Architecture](handout/redux/redux_and_component_architecture.md)
-   * [Getting More from Redux and Ngrx](handout/redux/getting_more_from_redux_and_ngrx.md)
+   * [Getting More From Redux and Ngrx](handout/redux/getting_more_from_redux_and_ngrx.md)
 ---
 
 * [TDD Testing](handout/testing/README.md)

--- a/handout/redux/README.md
+++ b/handout/redux/README.md
@@ -1,4 +1,4 @@
-# Redux
+# Redux and Ngrx
 
 ## What is Redux?
 
@@ -10,12 +10,14 @@ Where Flux applications traditionally have multiple stores, Redux applications
 have only one global, read-only application state. This state is calculated by
 "reducing" over a collection or stream of actions that update it in controlled ways.
 
-The Redux pattern has become very popular and has inspired
-[Ngrx](https://github.com/ngrx "ngrx collection") which is exclusive to
-Angular2/RxJS.
+One popular Angular 2 specific implementation of the Redux pattern is [Ng2-Redux](https://github.com/wbuchwalter/ng2-redux), which we'll be using to describe how to use this approach in an application.
 
-In this course we discuss a more traditional Redux pattern using the
-[Ng2-Redux](https://github.com/wbuchwalter/ng2-redux) bindings library.
+
+## What is Ngrx?
+
+Redux implementation has been very well received and has inspired the creation of [ngrx](https://github.com/ngrx "ngrx collection"), a set of modules that implement the same way of managing state as well as some of the middleware and tools in the Redux ecosystem. Ngrx was created to be used specifically with Angular 2 and [RxJS](https://github.com/Reactive-Extensions/RxJS), as it leans heavily on the observable paradigm. 
+
+Although we'll be using Ng2-Redux, a lot of the same lessons apply with regards to ngrx though the syntax may be different and have some slight differences in what abstractions are involved.
 
 ## Resources
 

--- a/handout/redux/getting_more_from_redux_and_ngrx.md
+++ b/handout/redux/getting_more_from_redux_and_ngrx.md
@@ -1,4 +1,4 @@
-# Getting More from Redux and Ngrx
+# Getting More From Redux and Ngrx
 
 Redux has a number of tools and middleware available in its ecosystem to facilitate elegant app development.
 

--- a/handout/redux/getting_more_from_redux_and_ngrx.md
+++ b/handout/redux/getting_more_from_redux_and_ngrx.md
@@ -1,0 +1,16 @@
+# Getting More from Redux and Ngrx
+
+Redux has a number of tools and middleware available in its ecosystem to facilitate elegant app development.
+
+- *[Redux DevTools](https://github.com/gaearon/redux-devtools)* - a tool that displays a linear timeline of actions that have interacted with its store. Allows for replaying actions and error handling
+- *[redux-thunk](https://github.com/gaearon/redux-thunk)* - middleware that enables lazy evaluation of actions
+- *[redux-saga](https://github.com/yelouafi/redux-saga)* - a model for performing side-effects
+- *[redux-observable](https://github.com/redux-observable/redux-observable)* - allows RxJS observables to be dispatched as actions
+
+# Ngrx
+
+Ngrx provides most of its Redux implementation through the [ngrx/store](https://github.com/ngrx/store) module. Other modules are available for better integration and development.
+
+- *[ngrx/store-devtools](https://github.com/ngrx/store-devtools)* - an ngrx implementation of the Redux DevTools
+- *[ngrx/effects](https://github.com/ngrx/effects)* - a model for performing side-effects similar to `redux-saga`
+- *[ngrx/router](https://github.com/ngrx/router)* and *[ngrx/router-store](https://github.com/ngrx/router-store)* - a router for Angular 2 that can be connected to your ngrx store

--- a/handout/redux/reducers_as_state_management.md
+++ b/handout/redux/reducers_as_state_management.md
@@ -1,4 +1,4 @@
-# Redux Reducers
+# Reducers as State Management
 
 This simple idea turns out to be very powerful. With Redux, you replay a series
 of events into the reducer and get your new application state as a result.
@@ -33,13 +33,13 @@ needing to explicitly subscribe to the dispatcher, every action gets passed into
 each reducer, which handles the actions it's interested in and then returns the
 new state along to the next reducer.
 
-Reducers in Redux should be side-effect free. This means that they should not
+Reducers should be side-effect free. This means that they should not
 modify things outside of their own scope. The should simply compute the next
 application state as a pure function of the reducer's arguments. 
 
 For this reason, side-effect causing operations, such as
 updating a record in a database, generating an id, etc. should be handled
-elsewhere in the application such as in the action creators or middleware.
+elsewhere in the application such as in the action creators, using middleware such as [redux-saga](https://github.com/yelouafi/redux-saga) or [ngrx/effects](https://github.com/ngrx/effects).
 
 Another consideration when creating your reducers is to ensure that they are immutable and not modifying the state of your application. If you mutate your application state, it can cause unexpected behavior. There are a few ways to help maintain immutability in your reducers. One way is by using new ES6 features such as `Object.assign` or the spread operator for arrays.
 

--- a/handout/redux/review_of_reducers_and_pure_functions.md
+++ b/handout/redux/review_of_reducers_and_pure_functions.md
@@ -1,8 +1,8 @@
 # Review of Reducers and Pure Functions
 
-One of the core concepts of Redux is the reducer. A reducer is simply a function that iterates over a collection of values, and returns a new single value at the end of it.
+One of the core concepts of Redux is the *reducer*. A reducer is a function with the signature `(accumulator: T, item: U) => T`. Reducers are often used in JavaScript through the `Array.reduce` method, which iterates over each of the array's items and accumulates a single value as a result. Reducers should be *pure functions*, meaning they don't generate any side-effects.
 
-A simple example of a reducer is a sum function:
+A simple example of a reducer is the sum function:
 
 ```javascript
 let x = [1,2,3].reduce((value,state)=>value+state,0)


### PR DESCRIPTION
Fixes #597 
- Changed section name to Redux and Ngrx
- Added more content to README.md regarding ngrx
- Changed implementation agnostic sections to avoid mentioning Redux if it makes sense to do so
- Added a Redux/Ngrx tools section to summarize some of the things that are possible with ngrx without going into code examples