### PR TITLE
Switch to new Rangle.io theme.

### DIFF
--- a/book.json
+++ b/book.json
@@ -2,14 +2,14 @@
   "plugins": [
     "image-captions",
     "highlight",
-    "theme-default",
+    "theme-rangle-io",
     "ga"
   ],
   "styles": {
     "ebook": "styles/ebook.css",
     "pdf": "styles/pdf.css"
   },
-  "theme": "theme-default",
+  "theme": "theme-rangle-io",
   "pluginsConfig": {
     "ga": {
       "token": "UA-41067508-7"


### PR DESCRIPTION
The rangle-io theme is identical to the default theme, but includes the rangle.io site navigation bar.

I tested this change with a temporary gitbook and it worked there.