### PR TITLE
fix(cd): Fix link to CD Enum

### DIFF
--- a/handout/change-detection/additional_resources.md
+++ b/handout/change-detection/additional_resources.md
@@ -3,7 +3,7 @@
 To learn more about change detection, visit the following links (in order of relevance):
 
 - [NgConf 2014: Change Detection (Video)](https://www.youtube.com/watch?v=jvKGQSFQf10)
-- [Angular API Docs: ChangeDetectionStrategy](https://angular.io/docs/ts/latest/api/core/ChangeDetectionStrategy-enum.html)
+- [Angular API Docs: ChangeDetectionStrategy](https://angular.io/docs/ts/latest/api/core/index/ChangeDetectionStrategy-enum.html)
 - [Victor Savkin Blog: Change Detection in Angular 2](http://victorsavkin.com/post/110170125256/change-detection-in-angular-2)
 - [Victor Savkin Blog: Two Phases of Angular 2 Applications](http://victorsavkin.com/post/114168430846/two-phases-of-angular-2-applications)
 - [Victor Savkin Blog: Angular, Immutability and Encapsulation](http://victorsavkin.com/post/133936129316/angular-immutability-and-encapsulation)


### PR DESCRIPTION
* GitBook issue -
* https://www.gitbook.com/book/rangle-io/ngcourse2/discussions/41

Updated to correct link, although link is now in 'additional resources'
and not where it was previously