### PR TITLE
Updates to the TDD chapter

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -204,6 +204,7 @@
    * [Test Setup](handout/testing/intro-to-tdd/setup/README.md)
        * [Filename Conventions](handout/testing/intro-to-tdd/setup/filename-conventions.md)
        * [Karma Configuration](handout/testing/intro-to-tdd/setup/karma-config.md)
+       * [TestBed Configuration (Optional)](handout/testing/intro-to-tdd/setup/testbed-configuration.md)
        * [Typings](handout/testing/intro-to-tdd/setup/typings.md)
        * [Executing Test Scripts](handout/testing/intro-to-tdd/setup/execute.md)
    * [Simple Test](handout/testing/intro-to-tdd/simple-test.md)

--- a/handout/testing/components/injecting-dependencies.md
+++ b/handout/testing/components/injecting-dependencies.md
@@ -35,12 +35,16 @@ In order to test this component we need initiate the `QuoteComponent` class. The
 ```js
 import { QuoteService } from './quote.service';
 import { QuoteComponent } from './quote.component';
-import { provide } from '@angular/core';
+import { provide, destroyPlatform } from '@angular/core';
 import {
   async,
   inject,
   TestBed,
 } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
 
 class MockQuoteService {
   public quote: string = 'Test quote';
@@ -54,7 +58,14 @@ describe('Testing Quote Component', () => {
 
   let fixture;
 
+  beforeEach(() => destroyPlatform());
+
   beforeEach(() => {
+    TestBed.initTestEnvironment(
+      BrowserDynamicTestingModule,
+      platformBrowserDynamicTesting()
+    );
+
     TestBed.configureTestingModule({
       declarations: [
         QuoteComponent
@@ -83,12 +94,18 @@ describe('Testing Quote Component', () => {
 ```
 [View Example](http://plnkr.co/edit/7KZu1Yg6kBX7rksrpRHV?p=preview)
 
-Testing the `QuoteComponent` is a fairly straightforward process. We want to create a `QuoteComponent`, feed it a quote and see if it appears in the DOM. This process requires us to create the component, pass in any dependencies, trigger the component to perform an action and then look at the DOM to see if the action is what we expected. Let's take a look at how this is accomplished with the above unit test.
+Testing the `QuoteComponent` is a fairly straightforward process. We want to create a `QuoteComponent`, feed it a quote and see if it appears in the DOM. This process requires us to create the component, pass in any dependencies, trigger the component to perform an action and then look at the DOM to see if the action is what we expected. 
+
+Let's take a look at how this is accomplished with the above unit test.
+
+We use `TestBed.initTestingEnvironment` to create a testing platform using `BrowserDynamicTestingModule` and `platformBrowserDynamicTesting` as arguments, which are also imported from angular and allow the application to be bootstrapped for testing. This is necessary for all unit tests that make use of `TestBed`. Notice that this platform is destroyed and reset before every new test runs.
 
 We use `TestBed.configureTestingModule` to feed in any dependencies that our component requires. Here our component depends on the `QuoteService` to get data. We mock this data ourselves thus giving us control over what value we expect to show up. It is good practice to separate component testing from service testing - this makes it easier to test as you are only focusing on a single aspect of the application at a time. If your service or component fails, how will you know which one was the culprit? We inject the `QuoteService` dependency using our mock class `MockQuoteService`, where we will provide mock data for the component to consume.
 
 Next we use `TestBed.createComponent(QuoteComponent)` to create a *fixture* for us to use in our tests. This will then create a new instance of our component, fulfilling any Angular-specific routines like dependency injection. A fixture is a powerful tool that allows us to query the DOM rendered by a component, as well as change DOM elements and component properties. It is the main access point of testing components and we use it extensively.
 
-In the `Should get quote` test we have gotten access to our component through the `fixture.componentInstance` property. We then call `getQuote` to kickstart our only action in the `QuoteComponent` component. We run the test when the fixture is stable by using its `whenStable` method which will ensure the promise inside the `getQuote()` has resolved. Giving the component a chance to set the quote value. We call `fixture.detectChanges` to keep an eye out for any changes taking place to the DOM, and use the `fixture.debugElement.nativeElement` property to get access to those underlying DOM elements. Now we can check to see if the DOM rendered by our `QuoteComponent` contains the quote that we mocked in through the `QuoteService`. The final line attempts to assert that the DOM's div tag contains the mocked quote 'Test Quote' inside. If it does, then our component passes the test and works as expected; if it doesn't, that means our component is not outputting quotes correctly.
+In the `Should get quote` test we have gotten access to our component through the `fixture.componentInstance` property. We then call `getQuote` to kickstart our only action in the `QuoteComponent` component. We run the test when the fixture is stable by using its `whenStable` method which will ensure the promise inside the `getQuote()` has resolved, giving the component a chance to set the quote value. We call `fixture.detectChanges` to keep an eye out for any changes taking place to the DOM, and use the `fixture.debugElement.nativeElement` property to get access to those underlying DOM elements. 
+
+Now we can check to see if the DOM rendered by our `QuoteComponent` contains the quote that we mocked in through the `QuoteService`. The final line attempts to assert that the DOM's div tag contains the mocked quote 'Test Quote' inside. If it does, then our component passes the test and works as expected; if it doesn't, that means our component is not outputting quotes correctly.
 
 We wrap `Should get quote` test in `async()`. This is to allow our tests run in an asynchronous test zone. Using `async` creates a test zone which will ensure that all asynchronous functions have resolved prior to ending the test.

--- a/handout/testing/components/injecting-dependencies.md
+++ b/handout/testing/components/injecting-dependencies.md
@@ -98,7 +98,7 @@ Testing the `QuoteComponent` is a fairly straightforward process. We want to cre
 
 Let's take a look at how this is accomplished with the above unit test.
 
-We use `TestBed.initTestingEnvironment` to create a testing platform using `BrowserDynamicTestingModule` and `platformBrowserDynamicTesting` as arguments, which are also imported from angular and allow the application to be bootstrapped for testing. This is necessary for all unit tests that make use of `TestBed`. Notice that this platform is destroyed and reset before every new test runs.
+We use `TestBed.initTestingEnvironment` to create a testing platform using `BrowserDynamicTestingModule` and `platformBrowserDynamicTesting` as arguments, which are also imported from angular and allow the application to be bootstrapped for testing. This is necessary for all unit tests that make use of `TestBed`. Notice that this platform is destroyed and reset before each test runs.
 
 We use `TestBed.configureTestingModule` to feed in any dependencies that our component requires. Here our component depends on the `QuoteService` to get data. We mock this data ourselves thus giving us control over what value we expect to show up. It is good practice to separate component testing from service testing - this makes it easier to test as you are only focusing on a single aspect of the application at a time. If your service or component fails, how will you know which one was the culprit? We inject the `QuoteService` dependency using our mock class `MockQuoteService`, where we will provide mock data for the component to consume.
 

--- a/handout/testing/intro-to-tdd/setup/karma-config.md
+++ b/handout/testing/intro-to-tdd/setup/karma-config.md
@@ -1,7 +1,12 @@
 # Karma Configuration
-Karma is the foundation of our testing workflow. It brings together our other testing tools to define the framework we want to use, the environment to test under, the specific actions we want to perform, etc. In order to do this Karma relies on a configuration file *karma.config.js*. You can seed a new configuration file though the `karma init` command, which will guide you through a few basic questions to get a bare minimum setup running. If we take a look at the *karma.config.js* file in angular-redux-starter we'll see a few important points of interest:
+Karma is the foundation of our testing workflow. It brings together our other testing tools to define the framework we want to use, the environment to test under, the specific actions we want to perform, etc. In order to do this Karma relies on a configuration file named by default *karma.conf.js*. 
+
+You can seed a new configuration file though the `karma init` command, which will guide you through a few basic questions to get a bare minimum setup running. If we take a look at the [*karma.conf.js* file in angular-redux-starter](https://github.com/rangle/angular2-redux-example/blob/master/karma.conf.js) we'll see a few important points of interest:
 
 ```js
+const loaders = require('./webpack/loaders');
+const plugins = require('./webpack/plugins');
+
 module.exports = (config) => {
   const coverage = config.singleRun ? ['coverage'] : [];
 
@@ -41,7 +46,22 @@ module.exports = (config) => {
       ],
     },
 
-    webpack: {...},
+    webpack: {
+      plugins,
+      entry: './src/tests.entry.ts',
+      devtool: 'inline-source-map',
+      resolve: {
+        extensions: ['.webpack.js', '.web.js', '.ts', '.js'],
+      },
+      module: {
+        rules:
+          combinedLoaders().concat(
+            config.singleRun
+              ? [ loaders.istanbulInstrumenter ]
+              : [ ]),
+      },
+      stats: { colors: true, reasons: true },
+    },
 
     webpackServer: {
       noInfo: true, // prevent console spamming when running in Karma!
@@ -76,24 +96,44 @@ module.exports = (config) => {
     captureTimeout: 6000,
   });
 };
-
-
 ```
 
+## Overview
 The configuration file is put together by exporting a function that accepts the configuration object that Karma is going to work with. Modifying certain properties on this object will tell Karma what it is we want to do. Let's go over some of the key properties used in this configuration file:
 
-- `frameworks` is a list of the testing frameworks we want to use. These frameworks must be installed through NPM as a dependency in our project or/and as a Karma plugin.
-- `files` is a list of files to be loaded into the browser/testing environment. This can also take the form of a glob pattern as it becomes rather tedious to manually add in a new file for each new testing script created. In the angular2-redux-starter *karma.config.js* we have put the testing files we wish to include in a separate file - *src/tests.entry.ts*, which includes a `require` call using a regex pattern for importing files with the **.spec.ts** file extension. As a project grows larger and the number of files to include grows in complexity it is good practice to put file imports in a separate file - this keeps the *karma.config.js* file cleaner and more readable. Here is what our *src/tests.entry.ts* looks like:
+### frameworks
+`frameworks` is a list of the testing frameworks we want to use. These frameworks must be installed through NPM as a dependency in our project or/and as a Karma plugin.
+
+### files
+
+`files` is a list of files to be loaded into the browser/testing environment. These are loaded sequentially, so order matters. The file list can also take the form of a glob pattern as it becomes rather tedious to manually add in a new file for each new testing script created. 
+
+In the angular2-redux-starter *karma.conf.js* we have put the testing files we wish to include in a separate file - *src/tests.entry.ts*, which includes a `require` call using a regex pattern for importing files with the **.spec.ts** file extension. As a project grows larger and the number of files to include grows in complexity it is good practice to put file imports in a separate file - this keeps the *karma.conf.js* file cleaner and more readable. Here is what our *src/tests.entry.ts* looks like:
 
 ```typescript
 let testContext = (<{ context?: Function }>require).context('./', true, /\.test\.ts/);
 testContext.keys().forEach(testContext);
 ```
 
-- `preprocessors` allow for some operation to be performed on the contents of a unit testing file before it is executed. These operations are carried out through the use of Karma plugins and are often used for transpiling operations. Since we are writing unit tests in TypeScript, *.ts* files must be transpiled into plain Javascript in order to run in a browser-based environment. In angular2-redux-starter this process is done with webpack, so we explicitly invoke the `webpack` processor on all of our testing files (those ending with *.spec.ts*). We also load any source map files originating from transpilation through the `sourcemap` processor.
-- `coverageReporter` is used to configure the output of results of our code coverage tool (our toolchain uses Istanbul). Here we have specified to output the results in JSON and HTML.  Reports will appear in the *coverage/* folder.
-- `reporters` is a list of reporters to use in the test cycle. Reporters can be thought of as modular tools used to report on some aspect of the testing routine outside of the core unit tests. Code coverage is an example of a reporter - we want it to report on how much of our code is being tested. [There are many more reporters available for Karma](https://www.npmjs.com/browse/keyword/karma-reporter) that can aid in crafting your testing workflow.
-- If the project uses webpack, then the property `webpack` in the Karma configuration object is where we can configure webpack with Karma. Using webpack we can configure how to bundle our unit tests; that is, whether to pack all tests into a single bundle, or each unit test in its own bundle, etc. Regardless, unit tests should not be bundled with the rest of the applications code (especially in production!). In angular2-redux-starter we have opted to bundle all unit tests together.
-- `port`, `browsers` and `singleRun` configure the environment our unit tests will run under. The `browsers` property specifies which browser we want Karma to launch and capture output from. We can use Chrome, Firefox, Safari, IE or Opera (requires additional Karma launcher to be installed for each respective browser). For a browser-less DOM instance we can use PhantomJS (as outlined in the toolchain section). We can also manually capture output from a browser by navigating to `http://localhost:port`, where port is the number specified in the `port` property (the default value is 9876 if not specified). The property `singleRun` controls how Karma executes, if set to `true`, Karma will start, launch configured browsers, run tests and then exit with a code of either `0` or `1` depending on whether or not all tests passed.
+### preprocessors
+`preprocessors` allow for some operation to be performed on the contents of a unit testing file before it is executed. These operations are carried out through the use of Karma plugins and are often used for transpiling operations. Since we are writing unit tests in TypeScript, *.ts* files must be transpiled into plain Javascript in order to run in a browser-based environment. 
 
-This is just a sample of the core properties in *karma.config.js* being used by angular2-redux-starter project. There are many more properties that can be used to extend and configure the functionality of Karma - [take a look at the official documentation for the full API breakdown](http://karma-runner.github.io/0.13/config/configuration-file.html).
+In angular2-redux-starter this process is done with webpack, so we explicitly invoke the `webpack` processor on all of our testing files (those ending with *.spec.ts*). We also load any source map files originating from transpilation through the `sourcemap` processor.
+
+### webpack
+If the project uses webpack, then the property `webpack` in the Karma configuration object is where we can configure webpack with Karma. In the angular2-redux-starter, plugins and loaders are exported from their own files to be imported by both the webpack config and the karma config, making the configuration object smaller.
+
+Using webpack, we can configure how to bundle our unit tests; that is, whether to pack all tests into a single bundle, or each unit test in its own bundle, etc. Regardless, unit tests should not be bundled with the rest of the applications code (especially in production!). In angular2-redux-starter we have opted to bundle all unit tests together.
+
+### coverageReporters and reporters
+`coverageReporter` is used to configure the output of results of our code coverage tool (our toolchain uses Istanbul). Here we have specified to output the results in JSON and HTML.  Reports will appear in the *coverage/* folder.
+
+`reporters` is a list of reporters to use in the test cycle. Reporters can be thought of as modular tools used to report on some aspect of the testing routine outside of the core unit tests. Code coverage is an example of a reporter - we want it to report on how much of our code is being tested. [There are many more reporters available for Karma](https://www.npmjs.com/browse/keyword/karma-reporter) that can aid in crafting your testing workflow.
+
+### Environment configuration
+`port`, `browsers` and `singleRun` configure the environment our unit tests will run under. The `browsers` property specifies which browser we want Karma to launch and capture output from. We can use Chrome, Firefox, Safari, IE or Opera (requires additional Karma launcher to be installed for each respective browser). For a browser-less DOM instance we can use PhantomJS (as outlined in the toolchain section). 
+
+We can also manually capture output from a browser by navigating to `http://localhost:port`, where port is the number specified in the `port` property (the default value is 9876 if not specified). The property `singleRun` controls how Karma executes, if set to `true`, Karma will start, launch configured browsers, run tests and then exit with a code of either `0` or `1` depending on whether or not all tests passed.
+
+## Additional Resources
+This is just a sample of the core properties in *karma.conf.js* being used by angular2-redux-starter project. There are many more properties that can be used to extend and configure the functionality of Karma - [take a look at the official documentation for the full API breakdown](http://karma-runner.github.io/0.13/config/configuration-file.html).

--- a/handout/testing/intro-to-tdd/setup/karma-config.md
+++ b/handout/testing/intro-to-tdd/setup/karma-config.md
@@ -1,92 +1,26 @@
 # Karma Configuration
 Karma is the foundation of our testing workflow. It brings together our other testing tools to define the framework we want to use, the environment to test under, the specific actions we want to perform, etc. In order to do this Karma relies on a configuration file named by default *karma.conf.js*. 
 
-You can seed a new configuration file though the `karma init` command, which will guide you through a few basic questions to get a bare minimum setup running. If we take a look at the customized [*karma.conf.js* file in angular-redux-starter](https://github.com/rangle/angular2-redux-example/blob/master/karma.conf.js) we'll see a few important points of interest:
+You can seed a new configuration file though the `karma init` command, which will guide you through a few basic questions to get a bare minimum setup running. 
+
+## Overview
+The configuration file is put together by exporting a function that accepts the configuration object that Karma is going to work with. Modifying certain properties on this object will tell Karma what it is we want to do. Let's go over some of the key properties used in this configuration file:
 
 ```js
-const loaders = require('./webpack/loaders');
-const plugins = require('./webpack/plugins');
 
 module.exports = (config) => {
   const coverage = config.singleRun ? ['coverage'] : [];
 
   config.set({
-    frameworks: [
-      'jasmine',
-    ],
+    frameworks: [...],
+    plugins: [ ... ],
+    files: [ ... ],
+    preprocessors: { ... },
 
-    plugins: [
-      'karma-jasmine',
-      'karma-sourcemap-writer',
-      'karma-sourcemap-loader',
-      'karma-webpack',
-      'karma-coverage',
-      'karma-remap-istanbul',
-      'karma-spec-reporter',
-      'karma-chrome-launcher',
-    ],
+    webpack: { ... },
 
-    files: [
-      './src/tests.entry.ts',
-      {
-        pattern: '**/*.map',
-        served: true,
-        included: false,
-        watched: true,
-      },
-    ],
-
-    preprocessors: {
-      './src/tests.entry.ts': [
-        'webpack',
-        'sourcemap',
-      ],
-      './src/**/!(*.test|tests.*).(ts|js)': [
-        'sourcemap',
-      ],
-    },
-
-    webpack: {
-      plugins,
-      entry: './src/tests.entry.ts',
-      devtool: 'inline-source-map',
-      resolve: {
-        extensions: ['.webpack.js', '.web.js', '.ts', '.js'],
-      },
-      module: {
-        rules:
-          combinedLoaders().concat(
-            config.singleRun
-              ? [ loaders.istanbulInstrumenter ]
-              : [ ]),
-      },
-      stats: { colors: true, reasons: true },
-    },
-
-    webpackServer: {
-      noInfo: true, // prevent console spamming when running in Karma!
-    },
-
-    reporters: ['spec']
-      .concat(coverage)
-      .concat(coverage.length > 0 ? ['karma-remap-istanbul'] : []),
-
-    remapIstanbulReporter: {
-      src: 'coverage/chrome/coverage-final.json',
-      reports: {
-        html: 'coverage',
-      },
-    },
-
-    coverageReporter: {
-      reporters: [
-        { type: 'json' },
-      ],
-      dir: './coverage/',
-      subdir: (browser) => {
-        return browser.toLowerCase().split(/[ /-]/)[0]; // returns 'chrome'
-      },
-    },
+    reporters: [ ... ],
+    coverageReporter: { ... },
 
     port: 9999,
     browsers: ['Chrome'], // Alternatively: 'PhantomJS'
@@ -98,13 +32,41 @@ module.exports = (config) => {
 };
 ```
 
-## Overview
-The configuration file is put together by exporting a function that accepts the configuration object that Karma is going to work with. Modifying certain properties on this object will tell Karma what it is we want to do. Let's go over some of the key properties used in this configuration file:
 
 ### frameworks
+```js
+frameworks: [
+  'jasmine',
+],
+```
 `frameworks` is a list of the testing frameworks we want to use. These frameworks must be installed through NPM as a dependency in our project or/and as a Karma plugin.
 
+### plugins
+
+```js
+plugins: [
+  'karma-jasmine',
+  'karma-webpack',
+  'karma-coverage',
+  'karma-remap-istanbul',
+  'karma-chrome-launcher',
+],
+```
+Plugins that integrate karma with testing frameworks like Jasmine or build systems like Webpack.
+
 ### files
+
+```js
+files: [
+  './src/tests.entry.ts',
+  {
+    pattern: '**/*.map',
+    served: true,
+    included: false,
+    watched: true,
+  },
+],
+```
 
 `files` is a list of files to be loaded into the browser/testing environment. These are loaded sequentially, so order matters. The file list can also take the form of a glob pattern as it becomes rather tedious to manually add in a new file for each new testing script created. 
 
@@ -116,24 +78,96 @@ testContext.keys().forEach(testContext);
 ```
 
 ### preprocessors
+```js
+preprocessors: {
+  './src/tests.entry.ts': [
+    'webpack',
+    'sourcemap',
+  ],
+  './src/**/!(*.test|tests.*).(ts|js)': [
+    'sourcemap',
+  ],
+}
+```
+
 `preprocessors` allow for some operation to be performed on the contents of a unit testing file before it is executed. These operations are carried out through the use of Karma plugins and are often used for transpiling operations. Since we are writing unit tests in TypeScript, *.ts* files must be transpiled into plain Javascript in order to run in a browser-based environment. 
 
 In angular2-redux-starter this process is done with webpack, so we explicitly invoke the `webpack` processor on all of our testing files (those ending with *.spec.ts*). We also load any source map files originating from transpilation through the `sourcemap` processor.
 
 ### webpack
+
+```js 
+ webpack: {
+  plugins,
+  entry: './src/tests.entry.ts',
+  devtool: 'inline-source-map',
+  resolve: {
+    extensions: ['.webpack.js', '.web.js', '.ts', '.js'],
+  },
+  module: {
+    rules:
+      combinedLoaders().concat(
+        config.singleRun
+          ? [ loaders.istanbulInstrumenter ]
+          : [ ]),
+  },
+  stats: { colors: true, reasons: true },
+},
+webpackServer: {
+  noInfo: true, // prevent console spamming when running in Karma!
+}
+```
+
 If the project uses webpack, then the property `webpack` in the Karma configuration object is where we can configure webpack with Karma. In the angular2-redux-starter, plugins and loaders are exported from their own files to be imported by both the webpack config and the karma config, making the configuration object smaller.
 
 Using webpack, we can configure how to bundle our unit tests; that is, whether to pack all tests into a single bundle, or each unit test in its own bundle, etc. Regardless, unit tests should not be bundled with the rest of the applications code (especially in production!). In angular2-redux-starter we have opted to bundle all unit tests together.
 
 ### coverageReporters and reporters
+
+```js
+reporters: ['spec']
+  .concat(coverage)
+  .concat(coverage.length > 0 ? ['karma-remap-istanbul'] : []),
+
+remapIstanbulReporter: {
+  src: 'coverage/chrome/coverage-final.json',
+  reports: {
+    html: 'coverage',
+  },
+},
+
+coverageReporter: {
+  reporters: [
+    { type: 'json' },
+  ],
+  dir: './coverage/',
+  subdir: (browser) => {
+    return browser.toLowerCase().split(/[ /-]/)[0]; // returns 'chrome'
+  },
+},
+```
+
 `coverageReporter` is used to configure the output of results of our code coverage tool (our toolchain uses Istanbul). Here we have specified to output the results in JSON and HTML.  Reports will appear in the *coverage/* folder.
 
 `reporters` is a list of reporters to use in the test cycle. Reporters can be thought of as modular tools used to report on some aspect of the testing routine outside of the core unit tests. Code coverage is an example of a reporter - we want it to report on how much of our code is being tested. [There are many more reporters available for Karma](https://www.npmjs.com/browse/keyword/karma-reporter) that can aid in crafting your testing workflow.
 
 ### Environment configuration
+``` js
+port: 9999,
+browsers: ['Chrome'], // Alternatively: 'PhantomJS'
+colors: true,
+logLevel: config.LOG_INFO,
+autoWatch: true,
+captureTimeout: 6000,
+```
+
 `port`, `browsers` and `singleRun` configure the environment our unit tests will run under. The `browsers` property specifies which browser we want Karma to launch and capture output from. We can use Chrome, Firefox, Safari, IE or Opera (requires additional Karma launcher to be installed for each respective browser). For a browser-less DOM instance we can use PhantomJS (as outlined in the toolchain section). 
 
 We can also manually capture output from a browser by navigating to `http://localhost:port`, where port is the number specified in the `port` property (the default value is 9876 if not specified). The property `singleRun` controls how Karma executes, if set to `true`, Karma will start, launch configured browsers, run tests and then exit with a code of either `0` or `1` depending on whether or not all tests passed.
 
+## Completed Configuration
+The net result of customizing all of these proprties is the [*karma.conf.js* file in angular-redux-starter](https://github.com/rangle/angular2-redux-example/blob/master/karma.conf.js).
+
 ## Additional Resources
 This is just a sample of the core properties in *karma.conf.js* being used by angular2-redux-starter project. There are many more properties that can be used to extend and configure the functionality of Karma - [take a look at the official documentation for the full API breakdown](http://karma-runner.github.io/0.13/config/configuration-file.html).
+

--- a/handout/testing/intro-to-tdd/setup/karma-config.md
+++ b/handout/testing/intro-to-tdd/setup/karma-config.md
@@ -1,7 +1,7 @@
 # Karma Configuration
 Karma is the foundation of our testing workflow. It brings together our other testing tools to define the framework we want to use, the environment to test under, the specific actions we want to perform, etc. In order to do this Karma relies on a configuration file named by default *karma.conf.js*. 
 
-You can seed a new configuration file though the `karma init` command, which will guide you through a few basic questions to get a bare minimum setup running. If we take a look at the [*karma.conf.js* file in angular-redux-starter](https://github.com/rangle/angular2-redux-example/blob/master/karma.conf.js) we'll see a few important points of interest:
+You can seed a new configuration file though the `karma init` command, which will guide you through a few basic questions to get a bare minimum setup running. If we take a look at the customized [*karma.conf.js* file in angular-redux-starter](https://github.com/rangle/angular2-redux-example/blob/master/karma.conf.js) we'll see a few important points of interest:
 
 ```js
 const loaders = require('./webpack/loaders');

--- a/handout/testing/intro-to-tdd/setup/testbed-configuration.md
+++ b/handout/testing/intro-to-tdd/setup/testbed-configuration.md
@@ -1,0 +1,64 @@
+# TestBed Configuration (Optional)
+
+As you will see in [Testing Components](handout/testing/components/README.md), real-world component testing often relies on the Angular2 testing utility `TestBed`, which requires some configuration. Most significantly, we need to use `TestBed.initTestEnvironment` to create a testing platform before we can use unit tests with `TestBed`. This testing environment would have to be created, destroyed and reset as appropriate before every unit test.
+
+In the angular2-redux-starter, this configuration is done in a [`tests.configure.ts`](https://github.com/rangle/angular2-redux-example/blob/master/src/tests.configure.ts) file and imported into every unit test for easy re-use.
+
+```ts
+import {
+  getTestBed,
+  ComponentFixtureAutoDetect,
+  TestBed,
+} from '@angular/core/testing';
+
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+export const configureTests = (configure: (testBed: TestBed) => void) => {
+  const testBed = getTestBed();
+
+  if (testBed.platform == null) {
+    testBed.initTestEnvironment(
+      BrowserDynamicTestingModule,
+      platformBrowserDynamicTesting());
+  }
+
+  testBed.configureCompiler({
+      providers: [
+        {provide: ComponentFixtureAutoDetect, useValue: true},
+      ]
+    });
+
+  configure(testBed);
+
+  return testBed.compileComponents().then(() => testBed);
+};
+```
+
+`tests.configure.ts` creates the testing platform if it doesn't already exist, compiles the template, and exports `configureTests` which can then be imported and used in our unit tests.
+
+```ts
+import { TestBed } from '@angular/core/testing';
+import { ExampleComponent } from './index';
+import { configureTests } from '../../tests.configure';
+import { AppModule } from '../../modules/app.module';
+
+describe('Component: Example', () => {
+  let fixture;
+
+  beforeEach(done => {
+    const configure = (testBed: TestBed) => {
+      testBed.configureTestingModule({
+        imports: [AppModule],
+      });
+    };
+
+    configureTests(configure).then(testBed => {
+      fixture = testBed.createComponent(ExampleComponent);
+      fixture.detectChanges();
+      done();
+    });
+  });
+  ```

--- a/handout/testing/intro-to-tdd/setup/testbed-configuration.md
+++ b/handout/testing/intro-to-tdd/setup/testbed-configuration.md
@@ -39,6 +39,8 @@ export const configureTests = (configure: (testBed: TestBed) => void) => {
 
 `tests.configure.ts` creates the testing platform if it doesn't already exist, compiles the template, and exports `configureTests` which can then be imported and used in our unit tests.
 
+Here's a look at how it would be used:
+
 ```ts
 import { TestBed } from '@angular/core/testing';
 import { ExampleComponent } from './index';

--- a/handout/testing/intro-to-tdd/setup/typings.md
+++ b/handout/testing/intro-to-tdd/setup/typings.md
@@ -1,2 +1,4 @@
 # Typings
-Since our project and unit tests are written in TypeScript, we need type definitions for the libraries we'll be writing our tests with (Chai and Jasmine). In [angular2-redux-example](https://github.com/rangle/angular2-redux-example) we have included these type definitions from `@types`.
+Since our project and unit tests are written in TypeScript, we need type definitions for the libraries we'll be writing our tests with (Chai and Jasmine). In [angular2-redux-example](https://github.com/rangle/angular2-redux-example) we have included these type definitions from `@types`. 
+
+If you're following the example of angular2-redux-starter and using a `tests.entry` file to specify your project testing requirements, bear in mind you'll also need to add node typings to your dependencies.


### PR DESCRIPTION
Closes #795

Update Summary:
- Corrected `karma.config.js` to `karma.conf.js` which is the default name
- Added information on initializing a TestBed platform
- Added an optional configuration section on creating a tests configuration file. Our starter repo does this and we make reference to it but never explain it or mention it anywhere.
- Expanded the webpack configuration in `karma.conf.js`
- Changed Karma Configuration to use paragraphs and headings instead of bullet points.
- Added note about node typings being required if you follow our advice and use a `tests.entry` file.
