### PR TITLE
Added `<% raw %>` blocks to 2 code blocks that were causing parsing problems

### DIFF
--- a/handout/pipes/custom_pipes.md
+++ b/handout/pipes/custom_pipes.md
@@ -36,6 +36,7 @@ and a variable number of arguments of any type and return a transformed ("piped"
 
 Each colon-delimited parameter in the template maps to one method argument in the same order.
 
+{% raw %}
 ```typescript
 import {Component} from '@angular/core';
 
@@ -53,4 +54,5 @@ export class Hello {
 }
 
 ```
+{% endraw %}
 [View Example](http://plnkr.co/edit/hFLQ3qyukTet1h7rREYW?p=preview)

--- a/handout/pipes/stateful_and_async_pipes.md
+++ b/handout/pipes/stateful_and_async_pipes.md
@@ -12,6 +12,7 @@ Angular 2 provides `AsyncPipe`, which is stateful.
 
 AsyncPipe can receive a `Promise` or `Observable` as input and subscribe to the input automatically, eventually returning the emitted value(s). It is stateful because the pipe maintains a subscription to the input and its returned values depend on that subscription.
 
+{% raw %}
 ```typescript
 import {Component} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
@@ -35,6 +36,7 @@ export class ProductPrice {
 }
 
 ```
+{% endraw %}
 [View Example](http://plnkr.co/edit/YrJEE5UBTlZ8HtfMGfR2?p=preview)
 
 ## Implementing Stateful Pipes ##


### PR DESCRIPTION
This may only fix an issue with Windows, but after much investigation with installed versions of the gitbooks-cli and gitbooks itself, I could not resolve the problem without this fix. Also, it would appear that many programming books written with gitbooks use this same strategy to resolve this issue (for example, DjangoGirls), so this fix seems appropriate.

I have verified that the compiled output is what is expected.