### PR TITLE
remove reimport of core root module in lazy module, closes #883

### DIFF
--- a/handout/modules/shared-di-tree.md
+++ b/handout/modules/shared-di-tree.md
@@ -39,8 +39,60 @@ import { SharedModule } from './shared/shared.module';
 export class AppModule {}
 ```
 
-Since we import the module with `forRoot` in our root application module, we **do not** need to import it in `LazyModule`. Reimporting core root modules defined with `forRoot` in lazily loaded modules can cause issues in your application.
+We should **only** call `forRoot` in the root application module and no where else. This ensures that only a single instance of your service exists at the root level. Calling `forRoot` in another module can register the service again in a different level of the DI tree. 
+
+Since `SharedModule` only consists of a service that Angular registers in the root app injector, we do not need to import it in `LazyModule`. This is because the lazy loaded module will already have access to services defined at the root level.
 
 [View Example](https://plnkr.co/edit/dPpc40plyI8iu8ogrf3e?p=preview)
 
 This time, whenever we change the value of the `counter` property, this value is shared between the `EagerComponent` and the `LazyComponent` proving that we are using the same instance of the `CounterService`.
+
+However it is very likely that we may have a component, pipe or directive defined in `SharedModule` that we'll need in another module. Take the following for example.
+
+_app/shared/shared.module.ts_
+
+```ts
+import { NgModule, ModuleWithProviders } from '@angular/core';
+import { CounterService } from './counter.service';
+
+import { HighlightDirective } from './highlight.directive';
+
+@NgModule({
+  declarations: [HighlightDirective],
+  exports: [ HighlightDirective ]
+})
+export class SharedModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: SharedModule,
+      providers: [CounterService]
+    };
+  }
+}
+```
+
+In here, we declare and export `HighlightDirective` so other modules that import `SharedModule` can use it in their templates. This means we can just import the module in `LazyModule` normally.
+
+_app/lazy/lazy.module.ts_
+
+```ts
+import { NgModule } from '@angular/core';
+
+import { SharedModule } from '../shared/shared.module';
+
+import { LazyComponent }   from './lazy.component';
+import { routing } from './lazy.routing';
+
+@NgModule({
+  imports: [
+    SharedModule,
+    routing
+  ],
+  declarations: [LazyComponent]
+})
+export class LazyModule {}
+```
+
+Now we can use this directive within `LazyModule` without creating another instance of `CounterService`.
+
+[View Example](https://plnkr.co/edit/kqat7k4YhLSDKrjr8x2f?p=preview)

--- a/handout/modules/shared-di-tree.md
+++ b/handout/modules/shared-di-tree.md
@@ -39,24 +39,8 @@ import { SharedModule } from './shared/shared.module';
 export class AppModule {}
 ```
 
-In contrast, when import the same module in our `LazyModule` we will not call the `forRoot` method because we don't want to register the service again in a different level of the DI tree, so the declaration of the `LazyModule` doesn't change.
+Since we import the module with `forRoot` in our root application module, we **do not** need to import it in `LazyModule`. Reimporting core root modules defined with `forRoot` in lazily loaded modules can cause issues in your application.
 
-_app/lazy/lazy.module.ts_
-
-```js
-...
-import { SharedModule } from '../shared/shared.module';
-
-@NgModule({
-  imports: [
-    SharedModule,
-    ...
-  ],
-  ...
-})
-export class LazyModule {}
-```
-
-[View Example](https://plnkr.co/edit/4jHjiq1ZlwSsHaBxbeqA?p=preview)
+[View Example](https://plnkr.co/edit/dPpc40plyI8iu8ogrf3e?p=preview)
 
 This time, whenever we change the value of the `counter` property, this value is shared between the `EagerComponent` and the `LazyComponent` proving that we are using the same instance of the `CounterService`.


### PR DESCRIPTION
Removes reimport of `SharedModule` in lazy loaded module (defined with `forRoot` in application root module)