### PR TITLE
Creation of EventEmitter with 'new' in example

### DIFF
--- a/handout/components/app_structure/two_way_data_binding.md
+++ b/handout/components/app_structure/two_way_data_binding.md
@@ -24,7 +24,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 })
 export class CounterComponent {
   @Input() count = 0;
-  @Output() countChange = EventEmitter<number>();
+  @Output() countChange = new EventEmitter<number>();
 
   increment() {
     this.count++;


### PR DESCRIPTION
Most likely the example is missing the `new` keyword.