### PR TITLE
[Issue-936] Removing NG1 Book and Discussion links

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -4,7 +4,4 @@ Over the last three and a half years, Angular has become the leading open source
 
 ## About Rangle’s Angular Training Book
 
-We developed this book to be used as course material for Rangle's Angular training, but many people have found it to be useful for learning Angular on their own. This book will cover the most important Angular topics, from getting started with the Angular toolchain to writing Angular applications in a scalable and maintainable manner.
-
-Rangle.io also has an [Angular 1.x](http://ngcourse-1.rangle.io/) book which is geared towards writing Angular 1.x applications in an Angular 2 style. We hope you enjoy this book. We welcome your feedback in the [Discussion Area](https://www.gitbook.com/book/rangle-io/ngcourse2/discussions).
-
+We developed this book to be used as course material for Rangle's Angular training, but many people have found it to be useful for learning Angular on their own. This book will cover the most important Angular topics, from getting started with the Angular toolchain to writing Angular applications in a scalable and maintainable manner. We hope you enjoy this book.


### PR DESCRIPTION
- Removes ngbook1 link
- Removes gitbook discussion link, it doesn't seem that this feature is available anymore