### PR TITLE
Issue #957: Spring 2021 Routing updates part one.

### DIFF
--- a/routing/README.md
+++ b/routing/README.md
@@ -1,4 +1,4 @@
 # Routing
 
-In this section we will discuss the role of routing in Single Page Applications and Angular's new component router.
+In this section we will discuss the role of routing in Single Page Applications and Angular's component router.
 

--- a/routing/aux-routes.md
+++ b/routing/aux-routes.md
@@ -1,6 +1,8 @@
 # Using Auxiliary Routes
 
-Angular supports the concept of auxiliary routes, which allow you to set up and navigate multiple independent routes in a single app. Each component has one primary route and zero or more auxiliary outlets. Auxiliary outlets must have unique name within a component.
+Angular supports the concept of auxiliary routes, which allow you to set up and navigate multiple independent routes in a single app. Auxiliary routes allow the user to access or toggle portions of the page, such as a side-bar or dialog, using the URL.  
+
+Each component has one primary route and zero or more auxiliary outlets. Auxiliary outlets must have unique name within a component.
 
 To define the auxiliary route we must first add a named router outlet where contents for the auxiliary route are to be rendered.
 

--- a/routing/child_routes.md
+++ b/routing/child_routes.md
@@ -85,11 +85,9 @@ export const routes: Routes = [
 
 Since the `Overview` child route of `product-details` has an empty path, it will be loaded by default. The `specs` child route remains the same.
 
-[View Example with child routes](https://plnkr.co/edit/MqNv6RyQvzsiZTp0Dkpf?p=preview)
+[View Example with child routes](https://stackblitz.com/github/rangle/angular-book-examples/tree/feat-child-routes)
 
 [View Example with route params & child routes](https://plnkr.co/edit/xFL7q0HeTGBPQT1ZiMnI?p=preview)
-
-> View examples running in full screen mode to see route changes in the URL.
 
 ## Accessing a Parent's Route Parameters
 
@@ -119,8 +117,6 @@ export default class Overview {
 
 [View Example child routes accessing parent's route parameters](https://plnkr.co/edit/7stoOP3oEl7dqwsgBgu9?p=preview)
 
-> View examples running in full screen mode to see route changes in the URL.
-
 ## Links
 
 Routes can be prepended with `/`, or `../`; this tells Angular where in the route tree to link to.
@@ -143,5 +139,4 @@ In the above example, the link for route one links to a child of the current rou
 
 [View Example with linking throughout route tree](https://plnkr.co/edit/gsJxf6ukOXd4kNjLLVR3?p=preview)
 
-> View examples running in full screen mode to see route changes in the URL.
 

--- a/routing/config.md
+++ b/routing/config.md
@@ -1,5 +1,7 @@
 # Configuring Routes
 
+The scaffolding for Angular Routing can be generated automatically when creating a new application using the angular cli.  This section describes manually adding routing to an existing application.
+
 ## Base URL Tag
 
 The Base URL tag must be set within the `<head>` tag of index.html:

--- a/routing/query_params.md
+++ b/routing/query_params.md
@@ -43,7 +43,7 @@ export default class ProductList {
 
   ngOnInit() {
     this.sub = this.route
-      .queryParams
+      .paramMap
       .subscribe(params => {
         // Defaults to 0 if no query param provided.
         this.page = +params['page'] || 0;

--- a/routing/routeparams.md
+++ b/routing/routeparams.md
@@ -79,9 +79,8 @@ export class LoanDetailsPage implements OnInit, OnDestroy {
 
 > The reason that the `params` property on `ActivatedRoute` is an Observable is that the router may not recreate the component when navigating to the same component. In this case the parameter may change without the component being recreated.
 
-[View Basic Example](https://plnkr.co/edit/UjUlWKpO0wxQfB3P6YUG?p=preview)
+[View Basic Example](https://stackblitz.com/github/rangle/angular-book-examples/tree/feat-router-route-params)
 
-[View Example with Programmatic Route Navigation](https://plnkr.co/edit/5R0URH14ZiVjx81HEZxL?p=preview)
+[View Example with Programmatic Route Navigation](https://stackblitz.com/github/rangle/angular-book-examples/tree/feat-programmatic-route-navigation)
 
-> View examples running in full screen mode to see route changes in the URL.
 

--- a/routing/routeroutlet.md
+++ b/routing/routeroutlet.md
@@ -22,7 +22,5 @@ export class AppComponent {}
 
 In the above example, the component corresponding to the route specified will be placed after the `<router-outlet></router-outlet>` element when the link is clicked.
 
-[View Example](https://plnkr.co/edit/OHfytJquXKm8jvSe2T9Y?p=preview)
-
-> View examples running in full screen mode to see route changes in the URL.
+[View Example](https://stackblitz.com/github/rangle/angular-book-examples/tree/feat-basic-router)
 


### PR DESCRIPTION
## Routing
- [X] Should we mention UrlTree? -> Mentioned in routing guard section 
- [X] Remove “new” from “new component router”

### Configuring Routes

#### Base URL Tag
- [X] Mention that generating a project via CLI will do this for you automatically
- [X] Is the demos sidenote necessary? (if Plunkr might no longer be used) -> It doesn't apply to Stackblitz, and the Plunkr demos don't run anyways, so these have all been removed

### Controlling Access to or from a Route
- [ ] In first guard example, remove line 16? -> I think this is referenced elsewhere in the example.  However the whole example should be revisited to reflect the current version of Angular.  Issue #962 added to address updates to the examples.

#### Async Route Guards
- [x] Mention UrlTree also being a possible return value
- [x] See Official Documentation… link should point to: https://angular.io/guide/router#preventing-unauthorized-access

### Passing Optional Parameters to a Route
- [x] Update queryParams with queryParamMap - the example needs some updates in general and will be addressed separately 
- [x] See Official Documentation… link should point to: https://angular.io/guide/router#accessing-query-parameters-and-fragments

### Using Auxiliary Routes
- [] Review the example and make sure it follows current Angular style - this doesn't seem too far off but all examples will be addressed separately.

Issue  #962 - added to address the examples.

I didn't notice any mention of adding routing to a module.  We may want to add an issue for this,
